### PR TITLE
Add task existence check before AWS CLI version check

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -123,11 +123,19 @@ callerIdentityJson=$(${AWS_CLI_BIN} sts get-caller-identity)
 ACCOUNT_ID=$(echo "${callerIdentityJson}" | jq -r ".Account")
 MY_IAM_ARN=$(echo "${callerIdentityJson}" | jq -r ".Arn")
 
-# Check whether the AWS CLI v1.19.28/v2.1.30 or later exists
+# Check task existence
 describedTaskJson=$(${AWS_CLI_BIN} ecs describe-tasks \
   --cluster "${CLUSTER_NAME}" \
   --tasks "${TASK_ID}" \
   --output json)
+existTask=$(echo "${describedTaskJson}" | jq -r ".tasks[0].taskDefinitionArn")
+if [[ "x${existTask}" = "xnull" ]]; then
+  printf "${COLOR_RED}Pre-flight check failed: The specified ECS task does not exist.\n\
+Make sure the parameters you have specified for cluster \"${CLUSTER_NAME}\" and task \"${TASK_ID}\" are both valid.\n"
+  exit 1
+fi
+
+# Check whether the AWS CLI v1.19.28/v2.1.30 or later exists
 executeCommandEnabled=$(echo "${describedTaskJson}" | jq -r ".tasks[0].enableExecuteCommand")
 if [[ "x${executeCommandEnabled}" = "xnull" ]]; then
   printf "${COLOR_RED}Pre-flight check failed: ECS Exec requires the AWS CLI v1.19.28/v2.1.30 or later.\n\


### PR DESCRIPTION
Added a TASK existence check before checking the AWS CLI,  because If the TASK specified in the second argument does not exist, the AWS CLI version upgrade message will be displayed.

```
$ bash check-ecs-exec.sh ecs-cluster-name aaaaaaaabbbbbbbbbbbbcccccccddddd
-------------------------------------------------------------
Prerequisites for check-ecs-exec.sh
-------------------------------------------------------------
  jq      | OK (~~~~)
  AWS CLI | OK (~~~~)
-------------------------------------------------------------
Prerequisites for the AWS CLI to use ECS Exec
-------------------------------------------------------------
Pre-flight check failed: ECS Exec requires the AWS CLI v1.19.28/v2.1.30 or later.
Please update the AWS CLI and try again?
  For v2: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
  For v1: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html
```