### PR TITLE
shebang must be placed at the first line.

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -1,7 +1,8 @@
+#!/usr/bin/env bash
+
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-#!/usr/bin/env bash
 # shellcheck disable=SC2059
 
 # Script Name: check-ecs-exec.sh


### PR DESCRIPTION
Hi! 

I'm using zsh. Currently, the script seems to run by a /bin/sh, not by bash.
shebang must be placed at the first line.

```console
$ echo $SHELL
/bin/zsh
$ ./check-ecs-exec.sh
./check-ecs-exec.sh: 10: set: Illegal option -o pipefail
```

After this patch applied, becomes to run as bash.

```console
$ ./check-ecs-exec.sh 
Usage:
  ./check-ecs-exec.sh YOUR_ECS_CLUSTER_NAME YOUR_ECS_TASK_ID
```


