### PR TITLE
Fix script execution when used by assumed roles from SSO

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -122,8 +122,7 @@ AWS_REGION=${AWS_REGION:-$REGION}
 
 callerIdentityJson=$(${AWS_CLI_BIN} sts get-caller-identity)
 ACCOUNT_ID=$(echo "${callerIdentityJson}" | jq -r ".Account")
-MY_IAM_ARN=$(echo "${callerIdentityJson}" | jq -r '.Arn |= sub("assumed-role"; "role") | .Arn')
-MY_IAM_ARN="${MY_IAM_ARN%\/*}"
+MY_IAM_ARN=$(echo "${callerIdentityJson}" | jq -r '.Arn |= sub("assumed-role"; "role") | .Arn' | cut -f1,2 -d'/')
 
 # Check task existence
 describedTaskJson=$(${AWS_CLI_BIN} ecs describe-tasks \

--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -122,7 +122,8 @@ AWS_REGION=${AWS_REGION:-$REGION}
 
 callerIdentityJson=$(${AWS_CLI_BIN} sts get-caller-identity)
 ACCOUNT_ID=$(echo "${callerIdentityJson}" | jq -r ".Account")
-MY_IAM_ARN=$(echo "${callerIdentityJson}" | jq -r ".Arn")
+MY_IAM_ARN=$(echo "${callerIdentityJson}" | jq -r '.Arn |= sub("assumed-role"; "role") | .Arn')
+MY_IAM_ARN="${MY_IAM_ARN%\/*}"
 
 # Check task existence
 describedTaskJson=$(${AWS_CLI_BIN} ecs describe-tasks \


### PR DESCRIPTION
Failed run example:

```
sindri->~ $ check-ecs-exec.sh <CLUSTER_ID> <TASK_ID>
-------------------------------------------------------------
Prerequisites for check-ecs-exec.sh
-------------------------------------------------------------
  jq      | OK (/usr/bin/jq)
  AWS CLI | OK (/usr/bin/aws)

-------------------------------------------------------------
Prerequisites for the AWS CLI to use ECS Exec
-------------------------------------------------------------
  AWS CLI Version        | OK (aws-cli/2.1.32 Python/3.8.8 Linux/5.9.16-1-MANJARO exe/x86_64.manjaro.20 prompt/off)
  Session Manager Plugin | OK (1.2.30.0)

-------------------------------------------------------------
Configurations for ECS task and other resources
-------------------------------------------------------------
Cluster: <CLUSTER_ID>
Task   : <TASK_ID>
-------------------------------------------------------------
  Cluster Configuration  | Audit Logging Not Configured
  Can I ExecuteCommand?  | arn:aws:sts::<ACCOUNT_ID>:assumed-role/<ROLE_NAME>/<SSO_IDENTIFIER>

An error occurred (InvalidInput) when calling the SimulatePrincipalPolicy operation: Invalid Entity Arn: arn:aws:sts::<ACCOUNT_ID>:assumed-role/<ROLE_NAME>/<SSO_IDENTIFIER> does not clearly define entity type and name.
```