### PR TITLE
Support using MFA devices for AWS CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ $ export AWS_REGION=us-west-2
 $ bash <( curl -Ls https://raw.githubusercontent.com/aws-containers/amazon-ecs-exec-checker/main/check-ecs-exec.sh ) <YOUR_ECS_CLUSTER_NAME> <YOUR_ECS_TASK_ID>
 ```
 
-_Example 3 - Switch AWS CLI binaries_
+_Example 3 - With MFA_
+
+The `check-ecs-exec.sh` automatically detects your MFA configuration for the AWS CLI. But you can also explicitly specify which MFA device to use by setting the ARN of the MFA device to `AWS_MFA_SERIAL` environment variable.
+
+_Example 4 - Switch AWS CLI binaries_
 
 If you have multiple AWS CLI installations in your environment, both AWS CLI v1 and v2 for example, you can choose which AWS CLI binary to use by passing the `AWS_CLI_BIN` env variable.
 


### PR DESCRIPTION
This PR implements MFA support for AWS CLI commands and closes #27 🚀

![image](https://user-images.githubusercontent.com/3761357/122242297-2b653480-cefe-11eb-9287-cce06fcd994a.png)

It reads the AWS CLI configuration (by `aws configure get mfa_serial`) to detect if it needs an MFA code to proceed. The script also accepts an environment variable `AWS_MFA_SERIAL` to set the ARN of the MFA device, instead of the AWS CLI configuration.

Try it with `AWS_PROFILE=<your-profile-here> bash <( curl -Ls https://raw.githubusercontent.com/toricls/amazon-ecs-exec-checker/support-mfa/check-ecs-exec.sh ) <ecs-cluster-name> <ecs-task-id>`.