### PR TITLE
Explicit error message on VPC endpoint check for shared VPC subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Note that the `Condition` element of the IAM policy is not currently supported t
 17. **_🟡 SSM PrivateLink "com.amazonaws.(region).ssmmessages" not found_**  
 The `check-ecs-exec.sh` found one or more VPC endpoints configured in the VPC for your task, so you **may** want to add an additional SSM PrivateLink for your VPC. Make sure your ECS task has proper outbound internet connectivity, and if it doesn't, then you **need** to configure an additional SSM PrivateLink for your VPC.
 
+18. **_🔴 VPC Endpoints | CHECK FAILED_**  
+The `check-ecs-exec.sh` doesn't support checking this item for shared VPC subnets using [AWS Resouce Access Manager (AWS RAM)](https://aws.amazon.com/ram/). In short, this may not an issue to use ECS Exec if your ECS task VPC doesn't have any VPC endpoint and the task has proper outbound internet connectivity. Make sure to consult your administrator with the official ECS Exec documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-considerations) to find if your VPC need to have an additional VPC endpoint.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -624,9 +624,9 @@ if [[ ! "x${ACCOUNT_ID}" = "x${subnetOwnerId}" ]]; then
   ## Shared Subnets (VPC) are not supported in Amazon ECS Exec Checker
   printf "${COLOR_RED}CHECK FAILED${COLOR_YELLOW}\n"
   printf "     Amazon ECS Exec Checker doesn't support VPC endpoint validation for AWS RAM shared VPC/subnets.\n"
-  printf "     Contact your administrator to confirm if the following resources require an additional VPC endpoint configuration.\n"
-  printf "     - VPC Endpoint: ${requiredEndpoint}\n"
-  printf "     - Resources: ${taskVpcId} and ${taskSubnetId}${COLOR_DEFAULT}\n"
+  printf "     Contact your administrator to find if the following resources require to have an additional VPC endpoint.\n"
+  printf "     - Resources: ${taskVpcId} and ${taskSubnetId}\n"
+  printf "     - VPC Endpoint: ${requiredEndpoint}${COLOR_DEFAULT}\n"
 else
   ## List Vpc Endpoints
   vpcEndpointsJson=$(${AWS_CLI_BIN} ec2 describe-vpc-endpoints \


### PR DESCRIPTION
Amazon ECS Exec Checker today checks the existence of VPC endpoints to presume if users need to configure an additional VPC endpoint to let the managed agent in an ECS task access the SSM APIs.

Although the strategy above works as expected for most _normal_ VPCs and subnets which are created in the same AWS account of the ECS cluster and task, the script doesn't show legitimate results when the VPC subnets are shared from a different AWS account via [AWS Resource Access Manager (AWS RAM)](https://aws.amazon.com/ram/) due to the current script implementation that lists the VPC endpoints within the context AWS account using the [`aws ec2 describe-vpc-endpoints --filters Name=vpc-id,Values="${taskVpcId}`](https://github.com/aws-containers/amazon-ecs-exec-checker/blob/v0.6/check-ecs-exec.sh#L620) command today.

In the above situation, the script cannot get the list of VPC endpoints under the VPC in the different AWS account (VPC owner) and just wrongly prints "No additional VPC endpoints required" even if the VPC actually requires an additional VPC endpoint `com.amazonaws.<region>.ssmmessages` to be configured.

With this PR, the script now explicitly shows an error message that Amazon ECS Exec Checker doesn't support AWS RAM shared VPC subnets today as the following screenshot.

<img width="1566" alt="Screen Shot 2021-06-24 at 8 58 39 AM" src="https://user-images.githubusercontent.com/3761357/123188751-8804b880-d4d7-11eb-9198-6ee941a296b5.png">