### PR TITLE
Fix display when EC2 or Task Role is not configured

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -499,7 +499,7 @@ if [[ "x${taskRoleArn}" = "xnull" ]]; then
 fi
 
 if [[ ! "x${hasRole}" = "xtrue" ]]; then
-  printf "${COLOR_DEFAULT}  EC2 or Task Role       | ${COLOR_RED}Not Configured"
+  printf "${COLOR_DEFAULT}  EC2 or Task Role       | ${COLOR_RED}Not Configured\n"
 else
   if [[ "x${isEC2Role}" = "xtrue" ]]; then
     printf "${COLOR_DEFAULT}  EC2 Role Permissions   | "


### PR DESCRIPTION
The results before and after the fix are as follows.

Before
```
$ ./check-ecs-exec.sh example fb2cd3c7074d4052912985dae174fa22
...
  EC2 or Task Role       | Not Configured  VPC Endpoints          | SKIPPED (vpc-07b899d4fb276ef4f - No additional VPC endpoints required)
```

After
```
$ ./check-ecs-exec.sh example fb2cd3c7074d4052912985dae174fa22
...
  EC2 or Task Role       | Not Configured
  VPC Endpoints          | SKIPPED (vpc-07b899d4fb276ef4f - No additional VPC endpoints required)
```