### PR TITLE
Force AWS CLI output format to json

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -48,6 +48,9 @@ set -euo pipefail
 # e.g. AWS_CLI_BIN=aws-v1 ./check-ecs-exec.sh YOUR_ECS_CLUSTER_NAME YOUR_ECS_TASK_ID
 AWS_CLI_BIN=${AWS_CLI_BIN:-aws}
 
+# Force AWS CLI output format to json to use jq to parse its output
+export AWS_DEFAULT_OUTPUT=json
+
 # Colors for output
 COLOR_DEFAULT='\033[0m'
 COLOR_RED='\033[0;31m'


### PR DESCRIPTION
This PR fixes #31.

The script cannot parse AWS CLI results if user runs the script with the [output format configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-format) other than `json`, such as `text` and `table` for example.

Now we explicitly export `json` for the [`AWS_DEFAULT_OUTPUT`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set) environment variable at the beginning of the script to ensure the script consistently runs regardless of the user output configuration.