### PR TITLE
Fix ShellCheck ignore rule

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -3,9 +3,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-CHECKER_VERSION=v0.7
-
 # shellcheck disable=SC2059
+
+CHECKER_VERSION=v0.7
 
 # Script Name: check-ecs-exec.sh
 # Usage      : bash ./check-ecs-exec.sh <YOUR_ECS_CLUSTER_NAME> <YOUR_ECS_TASK_ID>


### PR DESCRIPTION
ShellCheck rule SC2059 is not ignored, as requested. Following [ignore documentation](https://github.com/koalaman/shellcheck/wiki/Ignore):

> Note that the directive must be on the first line after the shebang with versions before 0.4.6. As of 0.4.6 comments and whitespace are allowed before filewide directives.