### PR TITLE
Restore color before exit 1

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -64,8 +64,7 @@ CLUSTER_NAME=${1:-None} # A cluster name or a full ARN of the cluster
 TASK_ID=${2:-None} # A task ID or a full ARN of the task
 if [[ "${CLUSTER_NAME}" = "None" || "${TASK_ID}" = "None" ]]; then
   printf "${COLOR_RED}Usage:\n" >&2
-  printf "  ./check-ecs-exec.sh YOUR_ECS_CLUSTER_NAME YOUR_ECS_TASK_ID\n" >&2
-  printf "${COLOR_DEFAULT}"
+  printf "  ./check-ecs-exec.sh YOUR_ECS_CLUSTER_NAME YOUR_ECS_TASK_ID${COLOR_DEFAULT}\n" >&2
   exit 1
 fi
 
@@ -112,8 +111,7 @@ printSectionHeaderLine
 # Check if jq command exists
 command -v jq >/dev/null 2>&1 && status="$?" || status="$?"
 if [[ ! "${status}" = 0 ]]; then
-  printf "${COLOR_RED}Pre-flight check failed: \`jq\` command is missing\n" >&2
-  printf "${COLOR_DEFAULT}"
+  printf "${COLOR_RED}Pre-flight check failed: \`jq\` command is missing${COLOR_DEFAULT}\n" >&2
   exit 1
 fi
 printf "${COLOR_DEFAULT}  jq      | ${COLOR_GREEN}OK ${COLOR_DEFAULT}($(which jq))\n"
@@ -121,8 +119,7 @@ printf "${COLOR_DEFAULT}  jq      | ${COLOR_GREEN}OK ${COLOR_DEFAULT}($(which jq
 # Check if aws command exists
 command -v "${AWS_CLI_BIN}" >/dev/null 2>&1 && status="$?" || status="$?"
 if [[ ! "${status}" = 0 ]]; then
-  printf "${COLOR_RED}Pre-flight check failed: \`${AWS_CLI_BIN}\` command is missing\n" >&2
-  printf "${COLOR_DEFAULT}"
+  printf "${COLOR_RED}Pre-flight check failed: \`${AWS_CLI_BIN}\` command is missing${COLOR_DEFAULT}\n" >&2
   exit 1
 fi
 printf "${COLOR_DEFAULT}  AWS CLI | ${COLOR_GREEN}OK ${COLOR_DEFAULT}($(which "${AWS_CLI_BIN}"))\n"
@@ -137,8 +134,7 @@ if [ "${AWS_REGION}" = "" ] && [ "${source_profile}" != "" ]; then
   export AWS_REGION="${region}"
 fi
 if [[ "${AWS_REGION}" = "" ]]; then
-  printf "${COLOR_RED}Pre-flight check failed: Missing AWS region. Use the \`aws configure set default.region\` command or set the \"AWS_REGION\" environment variable.\n" >&2
-  printf "${COLOR_DEFAULT}"
+  printf "${COLOR_RED}Pre-flight check failed: Missing AWS region. Use the \`aws configure set default.region\` command or set the \"AWS_REGION\" environment variable.${COLOR_DEFAULT}\n" >&2
   exit 1
 fi
 
@@ -185,11 +181,10 @@ CALLER_IAM_ARN=$(echo "${callerIdentityJson}" | jq -r ".Arn")
 case "${CALLER_IAM_ARN}" in
   *:user/*|*:role/*|*:group/* ) MY_IAM_ARN="${CALLER_IAM_ARN}";;
   *:assumed-role/*) MY_IAM_ARN=$(getRoleArnForAssumedRole "${callerIdentityJson}");;
-  * ) printf "${COLOR_RED}Pre-flight check failed: The ARN \"${CALLER_IAM_ARN}\" associated with the caller(=you) is not supported. Try again either with one of an IAM user, an IAM role, or an assumed IAM role.\n" >&2 && printf "${COLOR_DEFAULT}" && exit 1;;
+  * ) printf "${COLOR_RED}Pre-flight check failed: The ARN \"${CALLER_IAM_ARN}\" associated with the caller(=you) is not supported. Try again either with one of an IAM user, an IAM role, or an assumed IAM role.${COLOR_DEFAULT}\n" >&2 && exit 1;;
 esac
 if [[ "${MY_IAM_ARN}" = "" ]]; then
-  printf "${COLOR_RED}Unknown error: Failed to get the role ARN of the caller(=you).\n" >&2
-  printf "${COLOR_DEFAULT}"
+  printf "${COLOR_RED}Unknown error: Failed to get the role ARN of the caller(=you).${COLOR_DEFAULT}\n" >&2
   exit 1
 fi
 
@@ -201,8 +196,7 @@ describedTaskJson=$(${AWS_CLI_BIN} ecs describe-tasks \
 existTask=$(echo "${describedTaskJson}" | jq -r ".tasks[0].taskDefinitionArn")
 if [[ "${existTask}" = "null" ]]; then
   printf "${COLOR_RED}Pre-flight check failed: The specified ECS task does not exist.\n\
-Make sure the parameters you have specified for cluster \"${CLUSTER_NAME}\" and task \"${TASK_ID}\" are both valid.\n"
-  printf "${COLOR_DEFAULT}"
+Make sure the parameters you have specified for cluster \"${CLUSTER_NAME}\" and task \"${TASK_ID}\" are both valid.${COLOR_DEFAULT}\n"
   exit 1
 fi
 
@@ -212,8 +206,7 @@ if [[ "${executeCommandEnabled}" = "null" ]]; then
   printf "${COLOR_RED}Pre-flight check failed: ECS Exec requires the AWS CLI v1.19.28/v2.1.30 or later.\n\
 Please update the AWS CLI and try again?\n\
   For v2: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html\n\
-  For v1: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html\n"
-  printf "${COLOR_DEFAULT}"
+  For v1: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html${COLOR_DEFAULT}\n"
   exit 1
 fi
 awsCliVersion=$(${AWS_CLI_BIN} --version 2>&1)

--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -65,6 +65,7 @@ TASK_ID=${2:-None} # A task ID or a full ARN of the task
 if [[ "${CLUSTER_NAME}" = "None" || "${TASK_ID}" = "None" ]]; then
   printf "${COLOR_RED}Usage:\n" >&2
   printf "  ./check-ecs-exec.sh YOUR_ECS_CLUSTER_NAME YOUR_ECS_TASK_ID\n" >&2
+  printf "${COLOR_DEFAULT}"
   exit 1
 fi
 
@@ -112,6 +113,7 @@ printSectionHeaderLine
 command -v jq >/dev/null 2>&1 && status="$?" || status="$?"
 if [[ ! "${status}" = 0 ]]; then
   printf "${COLOR_RED}Pre-flight check failed: \`jq\` command is missing\n" >&2
+  printf "${COLOR_DEFAULT}"
   exit 1
 fi
 printf "${COLOR_DEFAULT}  jq      | ${COLOR_GREEN}OK ${COLOR_DEFAULT}($(which jq))\n"
@@ -120,6 +122,7 @@ printf "${COLOR_DEFAULT}  jq      | ${COLOR_GREEN}OK ${COLOR_DEFAULT}($(which jq
 command -v "${AWS_CLI_BIN}" >/dev/null 2>&1 && status="$?" || status="$?"
 if [[ ! "${status}" = 0 ]]; then
   printf "${COLOR_RED}Pre-flight check failed: \`${AWS_CLI_BIN}\` command is missing\n" >&2
+  printf "${COLOR_DEFAULT}"
   exit 1
 fi
 printf "${COLOR_DEFAULT}  AWS CLI | ${COLOR_GREEN}OK ${COLOR_DEFAULT}($(which "${AWS_CLI_BIN}"))\n"
@@ -135,6 +138,7 @@ if [ "${AWS_REGION}" = "" ] && [ "${source_profile}" != "" ]; then
 fi
 if [[ "${AWS_REGION}" = "" ]]; then
   printf "${COLOR_RED}Pre-flight check failed: Missing AWS region. Use the \`aws configure set default.region\` command or set the \"AWS_REGION\" environment variable.\n" >&2
+  printf "${COLOR_DEFAULT}"
   exit 1
 fi
 
@@ -181,10 +185,11 @@ CALLER_IAM_ARN=$(echo "${callerIdentityJson}" | jq -r ".Arn")
 case "${CALLER_IAM_ARN}" in
   *:user/*|*:role/*|*:group/* ) MY_IAM_ARN="${CALLER_IAM_ARN}";;
   *:assumed-role/*) MY_IAM_ARN=$(getRoleArnForAssumedRole "${callerIdentityJson}");;
-  * ) printf "${COLOR_RED}Pre-flight check failed: The ARN \"${CALLER_IAM_ARN}\" associated with the caller(=you) is not supported. Try again either with one of an IAM user, an IAM role, or an assumed IAM role.\n" >&2 && exit 1;;
+  * ) printf "${COLOR_RED}Pre-flight check failed: The ARN \"${CALLER_IAM_ARN}\" associated with the caller(=you) is not supported. Try again either with one of an IAM user, an IAM role, or an assumed IAM role.\n" >&2 && printf "${COLOR_DEFAULT}" && exit 1;;
 esac
 if [[ "${MY_IAM_ARN}" = "" ]]; then
   printf "${COLOR_RED}Unknown error: Failed to get the role ARN of the caller(=you).\n" >&2
+  printf "${COLOR_DEFAULT}"
   exit 1
 fi
 
@@ -197,6 +202,7 @@ existTask=$(echo "${describedTaskJson}" | jq -r ".tasks[0].taskDefinitionArn")
 if [[ "${existTask}" = "null" ]]; then
   printf "${COLOR_RED}Pre-flight check failed: The specified ECS task does not exist.\n\
 Make sure the parameters you have specified for cluster \"${CLUSTER_NAME}\" and task \"${TASK_ID}\" are both valid.\n"
+  printf "${COLOR_DEFAULT}"
   exit 1
 fi
 
@@ -207,6 +213,7 @@ if [[ "${executeCommandEnabled}" = "null" ]]; then
 Please update the AWS CLI and try again?\n\
   For v2: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html\n\
   For v1: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html\n"
+  printf "${COLOR_DEFAULT}"
   exit 1
 fi
 awsCliVersion=$(${AWS_CLI_BIN} --version 2>&1)


### PR DESCRIPTION
If we are using bash, our console will remain red after `exit 1`.
I add `printf "${COLOR_DEFAULT}"` before `exit 1` in check-ecs-exec.sh.

For example, when we are using CloudShell or Amazon Linux 2.
![image](https://user-images.githubusercontent.com/8069859/131866784-cd587ae6-5215-43f2-9351-43eb9e14f911.png)
