### PR TITLE
Support cygwin on Windows

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -125,7 +125,7 @@ fi
 printf "${COLOR_DEFAULT}  AWS CLI | ${COLOR_GREEN}OK ${COLOR_DEFAULT}($(which "${AWS_CLI_BIN}"))\n"
 
 # Find AWS region
-REGION=$(${AWS_CLI_BIN} configure get region || echo "")
+REGION=$(${AWS_CLI_BIN} configure get region | sed -e 's/\r//g' || echo "")
 export AWS_REGION=${AWS_REGION:-$REGION}
 # Check region configuration in "source_profile" if the user uses MFA configurations
 source_profile=$(${AWS_CLI_BIN} configure get source_profile || echo "")
@@ -209,7 +209,7 @@ Please update the AWS CLI and try again?\n\
   For v1: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html${COLOR_DEFAULT}\n"
   exit 1
 fi
-awsCliVersion=$(${AWS_CLI_BIN} --version 2>&1)
+awsCliVersion=$(${AWS_CLI_BIN} --version 2>&1 | sed -e 's/\r//g')
 printf "${COLOR_DEFAULT}  AWS CLI Version        | ${COLOR_GREEN}OK ${COLOR_DEFAULT}(${awsCliVersion})\n"
 
 # Check whether the Session Manager plugin exists


### PR DESCRIPTION
When running `check-ecs-exec.sh` in cygwin on Windows, the REGION variable contains a trailing carriage return character. The script terminates with the error message "' doesn't match a supported format." Removing the trailing carriage return character character allows the rest of the script to complete normally.

The displayed AWS CLI Version also has a trailing carriage return character, but this is only a cosmetic issue and doesn't affect the checks performed by the rest of the script.