### PR TITLE
FIX: fail get ap-northeast-1 using Mac

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -125,7 +125,7 @@ fi
 printf "${COLOR_DEFAULT}  AWS CLI | ${COLOR_GREEN}OK ${COLOR_DEFAULT}($(which "${AWS_CLI_BIN}"))\n"
 
 # Find AWS region
-REGION=$(${AWS_CLI_BIN} configure get region | sed -e 's/\r//g' || echo "")
+REGION=$(${AWS_CLI_BIN} configure get region | tr -d "\r" || echo "")
 export AWS_REGION=${AWS_REGION:-$REGION}
 # Check region configuration in "source_profile" if the user uses MFA configurations
 source_profile=$(${AWS_CLI_BIN} configure get source_profile || echo "")


### PR DESCRIPTION
I've fixed this bug report! ( #53 )  Here bug is from this #48, so I modified the codes so that  It doesn't use sed. 

Please review it.