### PR TITLE
Get the agent status from running containers

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -419,7 +419,7 @@ if [[ "${executeCommandEnabled}" = "false" ]]; then
 else
   printf "\n"
   printf "${COLOR_DEFAULT}    ----------\n"
-  agentsStatus=$(echo "${describedTaskJson}" | jq -r ".tasks[0].containers[].managedAgents[].lastStatus")
+  agentsStatus=$(echo "${describedTaskJson}" | jq -r '.tasks[0].containers[] | select(.managedAgents) | .managedAgents[].lastStatus')
   idx=0
   for _ in $agentsStatus; do
     containerName=$(echo "${describedTaskJson}" | jq -r ".tasks[0].containers[${idx}].name")


### PR DESCRIPTION
If a container fails to launch the `managedAgents` key will not be present , this changes filters those container by selecting only the ones that do have the key


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
