### PR TITLE
Support EBS attached ECS tasks

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -627,7 +627,7 @@ fi
 # If there is any VPC Endpoints configured for the task VPC, we assume you would need an additional SSM PrivateLink to be configured. (yellow)
 # TODO: In the ideal world, the script should simply check if the task can reach to the internet or not :)
 requiredEndpoint="com.amazonaws.${AWS_REGION}.ssmmessages"
-taskNetworkingAttachment=$(echo "${describedTaskJson}" | jq -r ".tasks[0].attachments[0]")
+taskNetworkingAttachment=$(echo "${describedTaskJson}" | jq -r ".tasks[0].attachments | map(select(.type==\"ElasticNetworkInterface\"))[0]")
 if [[ "${taskNetworkingAttachment}" = "null" ]]; then
   ## bridge/host networking (only for EC2)
   taskVpcId=$(echo "${describedContainerInstanceJson}" | jq -r ".containerInstances[0].attributes[] | select(.name==\"ecs.vpc-id\") | .value")
@@ -635,7 +635,7 @@ if [[ "${taskNetworkingAttachment}" = "null" ]]; then
   subnetJson=$(${AWS_CLI_BIN} ec2 describe-subnets --subnet-ids "${taskSubnetId}")
 else
   ## awsvpc networking (for both EC2 and Fargate)
-  taskSubnetId=$(echo "${describedTaskJson}" | jq -r ".tasks[0].attachments[0].details[] | select(.name==\"subnetId\") | .value")
+  taskSubnetId=$(echo "${describedTaskJson}" | jq -r ".tasks[0].attachments | map(select(.type==\"ElasticNetworkInterface\"))[0].details[] | select(.name==\"subnetId\") | .value")
   subnetJson=$(${AWS_CLI_BIN} ec2 describe-subnets --subnet-ids "${taskSubnetId}")
   taskVpcId=$(echo "${subnetJson}" | jq -r ".Subnets[0].VpcId")
 fi


### PR DESCRIPTION
The script check-ecs-exec.sh currently encounters a subnet ID parsing error when used with ECS tasks that have EBS volumes attached. The error arises because the script incorrectly assumes that the attachments array includes only network interfaces.

```
An error occurred (InvalidSubnetID.NotFound) when calling the DescribeSubnets operation: The subnet ID '' does not exist
```

The check-ecs-exec.sh script is designed to parse only ElasticNetworkInterface from the attachments array returned by the aws ecs describe-tasks command. If an ECS task has an EBS volume attached, the array might also contain AmazonElasticBlockStorage objects, which can lead to incorrect parsing if these are listed before any network interfaces.

Update the parsing logic within check-ecs-exec.sh to accurately handle multiple types of attachments, focusing specifically on ElasticNetworkInterface objects for subnet ID extraction. This ensures the script disregards any AmazonElasticBlockStorage objects or other non-network-related attachments that could interfere with the correct parsing process.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
