### PR TITLE
Get taskSubnetId by checking attachements widely

### DIFF
--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -635,7 +635,7 @@ if [[ "${taskNetworkingAttachment}" = "null" ]]; then
   subnetJson=$(${AWS_CLI_BIN} ec2 describe-subnets --subnet-ids "${taskSubnetId}")
 else
   ## awsvpc networking (for both EC2 and Fargate)
-  taskSubnetId=$(echo "${describedTaskJson}" | jq -r ".tasks[0].attachments[0].details[] | select(.name==\"subnetId\") | .value")
+  taskSubnetId=$(echo "${describedTaskJson}" | jq -r ".tasks[0].attachments[].details[] | select(.name==\"subnetId\") | .value")
   subnetJson=$(${AWS_CLI_BIN} ec2 describe-subnets --subnet-ids "${taskSubnetId}")
   taskVpcId=$(echo "${subnetJson}" | jq -r ".Subnets[0].VpcId")
 fi


### PR DESCRIPTION
~*Issue #, if available:*~

*Description of changes:*
In my describe-tasks json, `tasks[0].attachments` have ServiceConnect information firstly and ElasticNetworkInterface information secondly.
So, I cannot get my taskSubnetId by current logic and this script exits with an error.
I fixed it by checking attachements list widely. (Sorry, I don't know if this way is best.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
