### PR TITLE
add the check for pidMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ The `check-ecs-exec.sh` doesn't support checking this item for shared VPC subnet
 19. **🟡 Environment Variables : defined**  
 SSM uses the AWS SDK which uses the [default chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default) when determining authentication. This means if AWS_ACCESS_KEY, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY are defined in the environment variables and the permissions there do not provide the required permissions for SSM to work, then the execute-command will fail. It is recomended not to define these environment variables. 
 
+20. **🟡 PidMode : task**  
+If you are [sharing a PID namespace in a task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#other_task_definition_params), you can only start ECS Exec sessions into one container. See the "Considerations for using ECS Exec" in [the ECS official documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-considerations) for more details.
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ SSM uses the AWS SDK which uses the [default chain](https://docs.aws.amazon.com/
 
 20. **🟡 PidMode : task**  
 If you are [sharing a PID namespace in a task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#other_task_definition_params), you can only start ECS Exec sessions into one container. See the "Considerations for using ECS Exec" in [the ECS official documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-considerations) for more details.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/check-ecs-exec.sh
+++ b/check-ecs-exec.sh
@@ -714,4 +714,15 @@ for containerName in $containerNameList; do
   idx=$((idx+1))
 done
 
+# 12. Check PID mode
+pidMode=$(echo "${taskDefJson}" | jq -r ".taskDefinition.pidMode")
+printf "${COLOR_DEFAULT}  PidMode                | "
+if [[ ${pidMode} = "task" ]]; then
+  printf "${COLOR_YELLOW}${pidMode} \n"
+elif [[ ${pidMode} = "host" ]]; then
+  printf "${COLOR_GREEN}${pidMode} \n"
+else
+  printf "${COLOR_GREEN}Not Configured \n"
+fi
+
 printf "\n"


### PR DESCRIPTION
If users are sharing a PID namespace in a task, they can only start ECS Exec sessions into one container.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-considerations
> You can have only one ECS Exec session per process ID (PID) namespace. If you are sharing a PID namespace in a task, you can only start ECS Exec sessions into one container.

So, if pidMode is task, it would be nice exec checker could warn the mode.
related issue: #75