### PR TITLE
ci: migrate to built in shellcheck action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        run: find . -type f -name "*.sh" -exec shellcheck {} +


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Move to v4 of the `actions/checkout` action.
* The `shellcheck` binary should be included in the runner already, according to the [shellcheck docs](https://www.shellcheck.net/wiki/GitHub-Actions). We should use this rather then a 3P action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
